### PR TITLE
Add social links

### DIFF
--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -1,0 +1,14 @@
+<div class="social">
+  <a class="" href="#">
+    <i class="fa fa-2x fa-instagram" aria-hidden="true"></i>
+    <span class="sr-only">Instagram</span>
+  </a>
+  <a class="" href="#">
+    <i class="fa fa-2x fa-envelope-o" aria-hidden="true"></i>
+    <span class="sr-only">Email</span>
+  </a>
+  <a class="" href="#">
+    <i class="fa fa-2x fa-linkedin-square" aria-hidden="true"></i>
+    <span class="sr-only">Linkedin</span>
+  </a>
+</div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,6 +5,10 @@ layout: default
 
   <div class="{{ page.title }}">
     {{ content }}
+
+    {% if page.url == "/about" %}
+      {% include social-links.html %}
+    {% endif %}
   </div>
 
 </article>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -26,3 +26,14 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: 900;
   font-style: italic;
 }
+
+.sr-only {
+  clip: rect(0,0,0,0);
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+}

--- a/_sass/_styles.scss
+++ b/_sass/_styles.scss
@@ -175,3 +175,7 @@
     @include ms-respond(padding-left, 2);
   }
 }
+
+.social a {
+  @include ms-respond(margin-right, -1);
+}

--- a/about.md
+++ b/about.md
@@ -2,7 +2,7 @@
 layout: page
 title: About
 description: ""
-permalink: /about/
+permalink: /about
 ---
 
 # I'm a Graphic Designer & Artist based in Chicago.


### PR DESCRIPTION
Closes #5.

Create a social links include. Call the ‘include’ below content of a
page if it is the ‘/about’ page. Add style to give spacing between the
social links.
