### PR TITLE
Social icons

### DIFF
--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -1,13 +1,13 @@
 <div class="social">
-  <a class="" href="#">
+  <a href="https://www.instagram.com/laceedges/" target="_blank">
     <i class="fa fa-2x fa-instagram" aria-hidden="true"></i>
     <span class="sr-only">Instagram</span>
   </a>
-  <a class="" href="#">
+  <a href="mailto:raina.d.shannon@gmail.com">
     <i class="fa fa-2x fa-envelope-o" aria-hidden="true"></i>
-    <span class="sr-only">Email</span>
+    <span class="sr-only">Email raina.d.shannon@gmail.com</span>
   </a>
-  <a class="" href="#">
+  <a href="https://www.linkedin.com/in/raina-shannon-48063351" target="_blank">
     <i class="fa fa-2x fa-linkedin-square" aria-hidden="true"></i>
     <span class="sr-only">Linkedin</span>
   </a>

--- a/_sass/_links.scss
+++ b/_sass/_links.scss
@@ -25,15 +25,3 @@ $transition-time: 300ms;
 .About a:hover, .About a:active {
   color: $alternate;
 }
-
-.link:focus,
-.About a:focus {
-  color: $near-white;
-  background-color: $alternate;
-  transition: color $transition-time, background-color $transition-time;
-}
-
-.link:focus:active,
-.About a:focus:active {
-  background-color: transparent;
-}

--- a/_sass/_normalize.scss
+++ b/_sass/_normalize.scss
@@ -101,7 +101,7 @@ a {
  */
 
 a:focus {
-    outline: thin dotted;
+    outline: medium dotted;
 }
 
 /**

--- a/_sass/_styles.scss
+++ b/_sass/_styles.scss
@@ -176,6 +176,6 @@
   }
 }
 
-.social a {
+.social > a {
   @include ms-respond(margin-right, -1);
 }


### PR DESCRIPTION
Add real links to social links. Also add `target="_blank"` so that when you click the links, they open in a new tab.

I played around with different `:focus` states but then decided to stay with what `normalize.css` specifics. I just changed the width from `thin` to `medium` because I like things to be obvious.

I added `.social-links > a` because I need to get in the habit of being more specific with my CSS selectors. The `>` means direct descendent which speeds up the look up a tiny bit.
