### PR TITLE
sticky-footer Add footer back in

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,3 @@
-<!--<footer class="site-footer">
-  <p class="footer-content">Made with love by <a class="" href="coltborg.com">Colt Borg</a></p>
-</footer>-->
+<footer class="o-container c-footer">
+  <p class="c-footer__content">Copyright &copy; Raina Shannon 2016 | Made with love by <a class="" href="http://coltborg.com">Colt Borg</a></p>
+</footer>

--- a/_sass/_06-components.footer.scss
+++ b/_sass/_06-components.footer.scss
@@ -1,0 +1,7 @@
+.c-footer {
+  @include ms-respond(padding, 1);
+}
+
+.c-footer__content {
+  @include ms-respond(font-size, -1);
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -31,14 +31,15 @@
 
   // Components
   "06-components.main",
+  "06-components.portfolio",
   "06-components.about-page",
+  "06-components.post",
+  "06-components.footer",
   "06-components.buttons",
   "06-components.carousel",
   "06-components.main-header",
   "06-components.site-nav",
   "06-components.social-links",
-  "06-components.portfolio",
-  "06-components.post",
 
   // Trumps
   "07-trumps.utilities"


### PR DESCRIPTION
Tried to use flex to keep the footer at the bottom of the page when
content is short. But I need to add display: flex to my body, which
breaks the header.

It’s too much work to redo. So I’ll leave it as is.
