### PR TITLE
remove-baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "/raina-shannon" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "http://rainashannon.com" # the base hostname & protocol for your site
 
 # Build settings


### PR DESCRIPTION
Now that the custom domain is hooked up, there doesn’t need to be a
baseurl prefix

Remove it so that relative paths work correctly on production site
