### PR TITLE
masonry - Remove 4 columns are large screens

### DIFF
--- a/_sass/_05-objects.masonry.scss
+++ b/_sass/_05-objects.masonry.scss
@@ -36,11 +36,3 @@
     column-count: 3;
   }
 }
-
-@media only screen and (min-width: 70em) {
-  .masonry {
-    -moz-column-count: 4;
-    -webkit-column-count: 4;
-    column-count: 4;
-  }
-}


### PR DESCRIPTION
Columns should only span 3 columns max